### PR TITLE
Support general czi files

### DIFF
--- a/Ambia_core/src/utils/reading_czi.py
+++ b/Ambia_core/src/utils/reading_czi.py
@@ -72,10 +72,10 @@ def get_channel_info(slidepath):
     slide = slideio.open_slide(slidepath, "CZI")
     metadata = slide.raw_metadata
     root = ET.fromstring(metadata)
-    channels = root[0][4][3][11][0]
-    allchannels = channels.findall('Channel')
-    num_channels = len(allchannels)
-    channel_types = []
-    for channel in allchannels:
-        channel_types.append(channel.attrib['Name'])
+    channels = root.findall(
+        './Metadata/Information/Image/Dimensions/Channels/Channel'
+    )
+    num_channels = len(channels)
+    channel_types = [channel.attrib['Name'] for channel in channels]
+
     return num_channels, channel_types


### PR DESCRIPTION
Use XML tags to properly read the necessary metadata, using [XPath](https://docs.python.org/3/library/xml.etree.elementtree.html#xpath-support) specification.

This fixes #2.